### PR TITLE
feat(plugin): prevent plugin from loading in dev

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -3,16 +3,19 @@ const { resolve } = require('path')
 module.exports = function module (moduleOptions) {
   const options = this.options['google-analytics'] || moduleOptions
 
-  // see https://github.com/nuxt-community/analytics-module/issues/2
-  if (options.ua) {
-    options.id = options.ua
-    delete options.ua
-  }
+  // prevent plugin from loading in dev
+  if (!this.nuxt.options.dev) {
+    // see https://github.com/nuxt-community/analytics-module/issues/2
+    if (options.ua) {
+      options.id = options.ua
+      delete options.ua
+    }
 
-  this.addPlugin({
-    src: resolve(__dirname, './templates/plugin.js'),
-    fileName: 'google-analytics.js',
-    options,
-    ssr: false
-  })
+    this.addPlugin({
+      src: resolve(__dirname, './templates/plugin.js'),
+      fileName: 'google-analytics.js',
+      options,
+      ssr: false
+    })
+  }
 }


### PR DESCRIPTION
This just prevents Google Analytics from loading while developing. Do you think something like this should be a default or added to the moduleOptions?