### PR TITLE
Dont include analytics plugin if there no id specified

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -4,7 +4,7 @@ module.exports = function module (moduleOptions) {
   const options = this.options['google-analytics'] || moduleOptions
 
   // Don't include when no analytics id is given
-  if (!options.id || !options.ua) {
+  if (!(options.id || options.ua)) {
     return
   }
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -3,6 +3,11 @@ const { resolve } = require('path')
 module.exports = function module (moduleOptions) {
   const options = this.options['google-analytics'] || moduleOptions
 
+  // Don't include when no analytics id is given
+  if (!options.id || !options.ua) {
+    return
+  }
+
   // see https://github.com/nuxt-community/analytics-module/issues/2
   if (options.ua) {
     options.id = options.ua


### PR DESCRIPTION
Without it if no id specified it will break vue app, e.g. when used with vuetify buttons wont be able to be clicked.
Usefull for testing, when there no need for analytics to be used.